### PR TITLE
Handle non-numeric input in asNumber utility

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,11 @@ const clampDay = (d) => Math.max(1, Math.min(28, Number(d)||1));
 const nextMonthlyDateFrom = (day, fromISO) => { const d=clampDay(day); const ref = fromISO ? new Date(fromISO) : new Date(); const y=ref.getFullYear(), m=ref.getMonth(); const cand=new Date(y,m,d); const ref0=new Date(ref.toDateString()); const out=(cand>=ref0?cand:new Date(y,m+1,d)); return out.toISOString().slice(0,10); };
 const daysBetween = (a,b) => { const A=new Date(a), B=new Date(b); A.setHours(0,0,0,0); B.setHours(0,0,0,0); return Math.round((B-A)/86400000) };
 const fmtUSD = (n) => (n==null || isNaN(n) ? '—' : Number(n).toLocaleString(undefined,{style:'currency',currency:'USD',maximumFractionDigits:2}));
-const asNumber = (v) => v===''||v==null?null:Number(String(v).replace(/,/g,''));
+const asNumber = (v) => {
+  if (v === '' || v == null) return null;
+  const n = Number(String(v).replace(/,/g,''));
+  return isNaN(n) ? null : n;
+};
 const hexToRgb = (hex) => { const m = /^#?([a-f\\d]{2})([a-f\\d]{2})([a-f\\d]{2})$/i.exec(hex||'#3b82f6'); return m?{r:parseInt(m[1],16),g:parseInt(m[2],16),b:parseInt(m[3],16)}:{r:59,g:130,b:246}; };
 function h(tag, attrs={}, ...children){
   const el=document.createElement(tag);


### PR DESCRIPTION
## Summary
- Avoid propagating NaN by returning null from asNumber when input is non-numeric

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68accb1fc0cc832bb1a130a72494545b