### PR TITLE
Add utility module and tests for date helpers

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
 <body>
 <div class="app" id="app"><div id="boot">Loading app…</div></div>
 
+<script src="utils.js"></script>
 <script>
 /* ---------- Early widget registry (prevents undefined errors) ---------- */
 window.WidgetRegistry = window.WidgetRegistry || {}; // global
@@ -106,8 +107,6 @@ const $$=(s,el=document)=>Array.from(el.querySelectorAll(s));
 const uid=()=>Math.random().toString(36).slice(2)+Date.now().toString(36);
 const todayISO=()=>new Date().toISOString().slice(0,10);
 const clamp=(n,min,max)=>Math.max(min,Math.min(max,n));
-const clampDay = (d) => Math.max(1, Math.min(28, Number(d)||1));
-const nextMonthlyDateFrom = (day, fromISO) => { const d=clampDay(day); const ref = fromISO ? new Date(fromISO) : new Date(); const y=ref.getFullYear(), m=ref.getMonth(); const cand=new Date(y,m,d); const ref0=new Date(ref.toDateString()); const out=(cand>=ref0?cand:new Date(y,m+1,d)); return out.toISOString().slice(0,10); };
 const daysBetween = (a,b) => { const A=new Date(a), B=new Date(b); A.setHours(0,0,0,0); B.setHours(0,0,0,0); return Math.round((B-A)/86400000) };
 const fmtUSD = (n) => (n==null || isNaN(n) ? '—' : Number(n).toLocaleString(undefined,{style:'currency',currency:'USD',maximumFractionDigits:2}));
 const asNumber = (v) => {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "finance-tracker",
+  "version": "1.0.0",
+  "description": "",
+  "main": "utils.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,31 @@
+const { nextMonthlyDateFrom, clampDay } = require('../utils');
+
+describe('clampDay', () => {
+  test('clamps values above 28 to 28', () => {
+    expect(clampDay(31)).toBe(28);
+  });
+
+  test('clamps values below 1 to 1', () => {
+    expect(clampDay(0)).toBe(1);
+  });
+});
+
+describe('nextMonthlyDateFrom', () => {
+  const ref = '2024-05-10';
+
+  test('returns same month when day is after the reference date', () => {
+    expect(nextMonthlyDateFrom(11, ref)).toBe('2024-05-11');
+  });
+
+  test('returns same date when day equals the reference date', () => {
+    expect(nextMonthlyDateFrom(10, ref)).toBe('2024-05-10');
+  });
+
+  test('advances to next month when day is before the reference date', () => {
+    expect(nextMonthlyDateFrom(9, ref)).toBe('2024-06-09');
+  });
+
+  test('handles invalid day by clamping to 28', () => {
+    expect(nextMonthlyDateFrom(31, ref)).toBe('2024-05-28');
+  });
+});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,20 @@
+function clampDay(d){
+  return Math.max(1, Math.min(28, Number(d) || 1));
+}
+function nextMonthlyDateFrom(day, fromISO){
+  const d = clampDay(day);
+  const ref = fromISO ? new Date(fromISO) : new Date();
+  const y = ref.getFullYear();
+  const m = ref.getMonth();
+  const cand = new Date(y, m, d);
+  const ref0 = new Date(ref.toDateString());
+  const out = (cand >= ref0 ? cand : new Date(y, m + 1, d));
+  return out.toISOString().slice(0, 10);
+}
+if (typeof module !== 'undefined'){
+  module.exports = {clampDay, nextMonthlyDateFrom};
+}
+if (typeof window !== 'undefined'){
+  window.clampDay = clampDay;
+  window.nextMonthlyDateFrom = nextMonthlyDateFrom;
+}


### PR DESCRIPTION
## Summary
- move date helper functions to new `utils.js` module and expose globally
- add Jest tests covering date calculations and invalid-day clamping
- wire up test script in package.json

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68accd2b54bc832bbe34b1220481f0da