### PR TITLE
Add persistent save function with storage error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,6 +241,14 @@ function load(){
   }
 }
 
+function save(){
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (e) {
+    console.error('Failed to save state', e);
+  }
+}
+
 /* ---------- Derived / KPIs with caching ---------- */
 const cache={vers:{cards:0,entries:0,finAccounts:0,finEntries:0}, latestByCard:null, kpisCC:null, sTotal:null,sAvail:null,sRemain:null, finLatest:null,finKPIs:null};
 function bump(k){ cache.vers[k]=(cache.vers[k]||0)+1; }


### PR DESCRIPTION
## Summary
- add `save()` function to persist state under `STORAGE_KEY`
- catch and log `localStorage` write errors to avoid UI crashes

## Testing
- `npm test` *(fails: jest: not found)*
- `node - <<'NODE' ... save(); NODE`
- `node - <<'NODE' ... save(); NODE` *(localStorage throws)*

------
https://chatgpt.com/codex/tasks/task_e_68acd02acb38832ba403b9a1218bb17d