### PR TITLE
Validate monthly reference date

### DIFF
--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -28,4 +28,8 @@ describe('nextMonthlyDateFrom', () => {
   test('handles invalid day by clamping to 28', () => {
     expect(nextMonthlyDateFrom(31, ref)).toBe('2024-05-28');
   });
+
+  test('throws an error for invalid fromISO string', () => {
+    expect(() => nextMonthlyDateFrom(10, 'not-a-date')).toThrow('Invalid date string');
+  });
 });

--- a/utils.js
+++ b/utils.js
@@ -3,7 +3,10 @@ function clampDay(d){
 }
 function nextMonthlyDateFrom(day, fromISO){
   const d = clampDay(day);
-  const ref = fromISO ? new Date(fromISO) : new Date();
+  let ref = fromISO ? new Date(fromISO) : new Date();
+  if (fromISO && isNaN(ref.getTime())){
+    throw new Error(`Invalid date string: ${fromISO}`);
+  }
   const y = ref.getFullYear();
   const m = ref.getMonth();
   const cand = new Date(y, m, d);


### PR DESCRIPTION
## Summary
- Ensure `nextMonthlyDateFrom` throws an error when given an invalid ISO date string
- Test invalid `fromISO` inputs to verify error handling

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acd85051c0832b97745264ad277e0f