### PR TITLE
Use crypto.randomUUID for uid

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@ const WidgetRegistry = window.WidgetRegistry;
 /* ---------- Utilities ---------- */
 const $ = (s,el=document)=>el.querySelector(s);
 const $$=(s,el=document)=>Array.from(el.querySelectorAll(s));
-const uid=()=>Math.random().toString(36).slice(2)+Date.now().toString(36);
+const uid=()=>globalThis.crypto?.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)+Date.now().toString(36);
 const todayISO=()=>new Date().toISOString().slice(0,10);
 const clamp=(n,min,max)=>Math.max(min,Math.min(max,n));
 const daysBetween = (a,b) => { const A=new Date(a), B=new Date(b); A.setHours(0,0,0,0); B.setHours(0,0,0,0); return Math.round((B-A)/86400000) };


### PR DESCRIPTION
## Summary
- Replace Math.random-based uid with crypto.randomUUID() fallbacking to previous method when crypto is unavailable

## Testing
- `node -e "const uid=()=>globalThis.crypto?.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)+Date.now().toString(36); const id=uid(); console.log(id, typeof id);"`
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68acd85b7780832b92ef96799cdcd416