### PR TITLE
Refactor clamp helper into utils module

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,6 @@ const $ = (s,el=document)=>el.querySelector(s);
 const $$=(s,el=document)=>Array.from(el.querySelectorAll(s));
 const uid=()=>Math.random().toString(36).slice(2)+Date.now().toString(36);
 const todayISO=()=>new Date().toISOString().slice(0,10);
-const clamp=(n,min,max)=>Math.max(min,Math.min(max,n));
 const daysBetween = (a,b) => { const A=new Date(a), B=new Date(b); A.setHours(0,0,0,0); B.setHours(0,0,0,0); return Math.round((B-A)/86400000) };
 const fmtUSD = (n) => (n==null || isNaN(n) ? '—' : Number(n).toLocaleString(undefined,{style:'currency',currency:'USD',maximumFractionDigits:2}));
 const asNumber = (v) => {

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,8 @@
+function clamp(n, min, max){
+  return Math.max(min, Math.min(max, n));
+}
 function clampDay(d){
-  return Math.max(1, Math.min(28, Number(d) || 1));
+  return clamp(Number(d) || 1, 1, 28);
 }
 function nextMonthlyDateFrom(day, fromISO){
   const d = clampDay(day);
@@ -12,9 +15,10 @@ function nextMonthlyDateFrom(day, fromISO){
   return out.toISOString().slice(0, 10);
 }
 if (typeof module !== 'undefined'){
-  module.exports = {clampDay, nextMonthlyDateFrom};
+  module.exports = {clamp, clampDay, nextMonthlyDateFrom};
 }
 if (typeof window !== 'undefined'){
+  window.clamp = clamp;
   window.clampDay = clampDay;
   window.nextMonthlyDateFrom = nextMonthlyDateFrom;
 }


### PR DESCRIPTION
## Summary
- add generic `clamp` helper to `utils.js` and export it for browser and Node
- remove inline `clamp` definition from `index.html` and rely on shared util

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68acd86467ac832bb012adfadffa9c71