### PR TITLE
Fix monthly date calculation to be UTC-safe

### DIFF
--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -33,3 +33,24 @@ describe('nextMonthlyDateFrom', () => {
     expect(() => nextMonthlyDateFrom(10, 'not-a-date')).toThrow('Invalid date string');
   });
 });
+
+describe('timezone handling', () => {
+  const ref = '2024-05-10';
+  const originalTZ = process.env.TZ;
+
+  afterEach(() => {
+    process.env.TZ = originalTZ;
+  });
+
+  test('works in a timezone west of UTC', () => {
+    process.env.TZ = 'America/Los_Angeles';
+    expect(nextMonthlyDateFrom(10, ref)).toBe('2024-05-10');
+    expect(nextMonthlyDateFrom(9, ref)).toBe('2024-06-09');
+  });
+
+  test('works in a timezone east of UTC', () => {
+    process.env.TZ = 'Asia/Tokyo';
+    expect(nextMonthlyDateFrom(10, ref)).toBe('2024-05-10');
+    expect(nextMonthlyDateFrom(9, ref)).toBe('2024-06-09');
+  });
+});

--- a/utils.js
+++ b/utils.js
@@ -30,15 +30,23 @@ function clampDay(d){
  */
 function nextMonthlyDateFrom(day, fromISO){
   const d = clampDay(day);
-  let ref = fromISO ? new Date(fromISO) : new Date();
-  if (fromISO && isNaN(ref.getTime())){
-    throw new Error(`Invalid date string: ${fromISO}`);
+  let ref;
+  if (fromISO){
+    // Parse bare YYYY-MM-DD strings as UTC to avoid timezone shifts.
+    ref = new Date(/^\d{4}-\d{2}-\d{2}$/.test(fromISO)
+      ? `${fromISO}T00:00:00Z`
+      : fromISO);
+    if (isNaN(ref.getTime())){
+      throw new Error(`Invalid date string: ${fromISO}`);
+    }
+  } else {
+    ref = new Date();
   }
-  const y = ref.getFullYear();
-  const m = ref.getMonth();
-  const cand = new Date(y, m, d);
-  const ref0 = new Date(ref.toDateString());
-  const out = (cand >= ref0 ? cand : new Date(y, m + 1, d));
+  const y = ref.getUTCFullYear();
+  const m = ref.getUTCMonth();
+  const cand = new Date(Date.UTC(y, m, d));
+  const ref0 = new Date(Date.UTC(y, m, ref.getUTCDate()));
+  const out = (cand >= ref0 ? cand : new Date(Date.UTC(y, m + 1, d)));
   // toISOString().slice(0, 10) returns a YYYY-MM-DD string.
   return out.toISOString().slice(0, 10);
 }


### PR DESCRIPTION
## Summary
- Parse `fromISO` as a UTC date and construct all comparisons via `Date.UTC` to avoid timezone shifts
- Add test coverage for environments west and east of UTC

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install --no-save jest` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ace0e4c954832b8009d35f2d549f00