### PR TITLE
Allow column-based widget layout with column selection

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -874,7 +874,10 @@ function ensureDashOrder(dash,key){
 function emptyNotice(){ return h('div',{class:'panel p4'}, h('div',{class:'muted'},'No widgets selected. Click "Customize" above to add widgets.')); }
 function buildGrid(orderKey, dash, gridId){
   ensureDashOrder(dash, orderKey);
-  const grid=h('div',{class:'grid grid-3',id:gridId});
+  const colCount = state.ui?.colCount?.[dash] || 3;
+  const grid=h('div',{class:'grid grid-'+colCount,id:gridId});
+  const cols = Array.from({length:colCount},(_,i)=> h('div',{class:'grid column-grid',style:'display:flex;flex-direction:column'},[]));
+  cols.forEach(c=>grid.appendChild(c));
   const list=(state[orderKey]||[]);
   for(const id of list){
     const meta=(WidgetRegistry && WidgetRegistry[id])? WidgetRegistry[id] : null;
@@ -882,10 +885,15 @@ function buildGrid(orderKey, dash, gridId){
     const built = meta.build();
     const el = widget(id, built, state.widgetSize[id]||meta.size||1, state.widgetHeightMode[id]||'auto');
     if (state.ui.customizing===dash) addWidgetControls(el, id, orderKey);
-    grid.appendChild(el);
+    const colIdx = Math.max(1, Math.min(colCount, state.widgetCol[id]||1)) - 1;
+    cols[colIdx].appendChild(el);
   }
-  if(!grid.children.length) grid.appendChild(emptyNotice());
-  setTimeout(()=> enableDrag(grid, orderKey), 0);
+  if(!list.length){
+    grid.innerHTML='';
+    grid.appendChild(emptyNotice());
+  }else{
+    setTimeout(()=> cols.forEach(c=> enableDrag(c, orderKey, grid)), 0);
+  }
   return grid;
 }
 function overview(){


### PR DESCRIPTION
## Summary
- Group dashboard widgets into separate columns using `state.widgetCol`
- Render each column as its own grid container to prevent cross-row alignment issues
- Add controls to choose a widget's column and adjust drag ordering to work per-column

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acecb1c510832b982569d986767c86