### PR TITLE
fix: use relative paths for Vite build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ npm start
 
 or open `index.html` directly in your browser for a static preview.
 
+To build a production bundle (useful for GitHub Pages deployments), run:
+
+```bash
+npm run build
+```
+
+The compiled assets will be output to the `dist/` folder.
+
 ## Tests
 
 ```bash
@@ -57,4 +65,5 @@ under the key `cc-finance-tracker-v27`. Clearing your browser data will reset th
 
 A GitHub Pages deployment is available for an immediate preview:
 
-[Finance Tracker Demo](https://example.github.io/finance-tracker/)
+1. Enable GitHub Pages in your repository settings and point it to the `dist/` directory after running the build command above.
+2. Visit `https://<your-user>.github.io/Finance-Tracker/` to view the site once the deployment finishes.

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,4 +2,8 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   root: '.',
+  // Use relative paths so built assets work on GitHub Pages and other
+  // subdirectory deployments instead of assuming the site is served from
+  // the domain root.
+  base: './',
 });


### PR DESCRIPTION
## Summary
- configure Vite to output relative asset paths so GitHub Pages loads correctly
- document production build and GitHub Pages deployment instructions

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acf09fcdb4832bb0acd3d459c33c03