### PR TITLE
refactor: centralize DOM utilities to break circular imports

### DIFF
--- a/src/charts.js
+++ b/src/charts.js
@@ -1,4 +1,4 @@
-import {h} from './app.js';
+import {h} from './dom-utils.js';
 
 export function barChart(items,{colors=[],valueSuffix='',currency=false,yMin=null,yMax=null}={}){
   if(!items||!items.length) return h('div',{class:'muted'},'No data');

--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -1,0 +1,23 @@
+export const $ = (s, el = document) => el.querySelector(s);
+export const $$ = (s, el = document) => Array.from(el.querySelectorAll(s));
+export const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
+
+export function h(tag, attrs = {}, ...children) {
+  const el = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs || {})) {
+    if (k === 'class') el.className = v;
+    else if (k.startsWith('on') && typeof v === 'function')
+      el.addEventListener(k.slice(2).toLowerCase(), v, { passive: true });
+    else if (k === 'style' && typeof v === 'object')
+      el.setAttribute('style', Object.entries(v).map(([a, b]) => `${a}:${b}`).join(';'));
+    else if (v !== false && v != null) el.setAttribute(k, v === true ? '' : v);
+  }
+  for (const c of children.flat()) {
+    if (c == null || c === false) continue;
+    if (typeof c === 'string' || typeof c === 'number' || typeof c === 'boolean')
+      el.appendChild(document.createTextNode(String(c)));
+    else el.appendChild(c);
+  }
+  return el;
+}
+

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -1,41 +1,56 @@
-import {h, $, $$, clamp, state, save, render, configureWidget} from './app.js';
-
-export function widget(id, content, size, heightMode){ const el=h('section',{class:'panel p4 drag',draggable:'true','data-widget-id':id, style:`grid-column: span ${Math.max(1,size||1)}`}, content);
+import {h, $, $$, clamp} from './dom-utils.js';
+export function widget(id, content, size, heightMode, {state}) {
+  const el = h('section', {
+    class: 'panel p4 drag',
+    draggable: 'true',
+    'data-widget-id': id,
+    style: `grid-column: span ${Math.max(1, size || 1)}`
+  }, content);
   const hmode = heightMode || state.widgetHeightMode[id] || 'auto';
-  let hpx = null; if (hmode==='short') hpx=240; else if(hmode==='medium') hpx=340; else if(hmode==='tall') hpx=440; else if(hmode==='fixed') hpx = clamp(Number(state.widgetFixedH[id]||320), 180, 900);
-  if (hmode!=='auto'){ el.style.maxHeight = hpx+'px'; el.style.overflow='auto'; }
+  let hpx = null;
+  if (hmode === 'short') hpx = 240;
+  else if (hmode === 'medium') hpx = 340;
+  else if (hmode === 'tall') hpx = 440;
+  else if (hmode === 'fixed') hpx = clamp(Number(state.widgetFixedH[id] || 320), 180, 900);
+  if (hmode !== 'auto') {
+    el.style.maxHeight = hpx + 'px';
+    el.style.overflow = 'auto';
+  }
   return el;
 }
-export function addWidgetControls(wrapper, id, orderKey){
+
+export function addWidgetControls(wrapper, id, orderKey, {state, save, render, configureWidget}) {
   const size = state.widgetSize[id] || 1;
   const hmode = state.widgetHeightMode[id] || 'auto';
-  const row=h('div',{style:'display:flex;gap:8px;justify-content:flex-end;margin-bottom:6px;align-items:center;'},
-    h('div',{class:'sizepick'},
-      ...[1,2,3,4,5,6].map(n=> h('button',{'aria-pressed': String(size===n), onclick:()=>{ state.widgetSize[id]=n; save(); wrapper.style.gridColumn='span '+n; }}, String(n)))
+  const row = h('div', { style: 'display:flex;gap:8px;justify-content:flex-end;margin-bottom:6px;align-items:center;' },
+    h('div', { class: 'sizepick' },
+      ...[1, 2, 3, 4, 5, 6].map(n => h('button', { 'aria-pressed': String(size === n), onclick: () => { state.widgetSize[id] = n; save(); wrapper.style.gridColumn = 'span ' + n; } }, String(n)))
     ),
-    h('div',{class:'field',style:'width:160px;'}, h('label',null,'Height'),
-      h('select',{onchange:e=>{ state.widgetHeightMode[id]=e.target.value; save(); render(); }},
-        ...[['auto','Auto'],['short','Short'],['medium','Medium'],['tall','Tall'],['fixed','Fixed px']].map(([v,l])=> h('option',{value:v, selected: hmode===v?'selected':null}, l))
+    h('div', { class: 'field', style: 'width:160px;' }, h('label', null, 'Height'),
+      h('select', { onchange: e => { state.widgetHeightMode[id] = e.target.value; save(); render(); } },
+        ...[['auto', 'Auto'], ['short', 'Short'], ['medium', 'Medium'], ['tall', 'Tall'], ['fixed', 'Fixed px']].map(([v, l]) => h('option', { value: v, selected: hmode === v ? 'selected' : null }, l))
       )
     ),
-    h('div',{class:'field',style:'width:110px;'+(hmode==='fixed'?'':'display:none;')}, h('label',null,'Pixels'),
-      h('input',{type:'number',value:String(state.widgetFixedH[id]||320),oninput:e=>{ state.widgetFixedH[id]=e.target.value; save(); render(); }})
-     ),
-      h('button',{class:'btn tiny',onclick:()=> configureWidget(id)},'Configure'),
-      h('button',{class:'btn tiny',onclick:()=>{ state[orderKey]=state[orderKey].filter(x=>x!==id); save(); render(); }},'Remove')
+    h('div', { class: 'field', style: 'width:110px;' + (hmode === 'fixed' ? '' : 'display:none;') }, h('label', null, 'Pixels'),
+      h('input', { type: 'number', value: String(state.widgetFixedH[id] || 320), oninput: e => { state.widgetFixedH[id] = e.target.value; save(); render(); } })
+    ),
+    h('button', { class: 'btn tiny', onclick: () => configureWidget(id) }, 'Configure'),
+    h('button', { class: 'btn tiny', onclick: () => { state[orderKey] = state[orderKey].filter(x => x !== id); save(); render(); } }, 'Remove')
   );
   wrapper.prepend(row);
 }
-export function enableDrag(container, orderKey){
-  const grid = typeof container==='string'? document.getElementById(container) : container;
+
+export function enableDrag(container, orderKey, {state, save}) {
+  const grid = typeof container === 'string' ? document.getElementById(container) : container;
   if (!grid) return;
-  let dragging=null, placeholder=null;
-  function onDragStart(e){ const el=e.currentTarget; dragging=el; el.classList.add('dragging'); e.dataTransfer.effectAllowed='move'; placeholder=document.createElement('div'); placeholder.className='placeholder'; placeholder.style.gridColumn=el.style.gridColumn||'span 1'; el.after(placeholder); }
-  function onDragOver(e){ e.preventDefault(); const target=e.target.closest('[data-widget-id]'); if(!target || target===dragging || !grid.contains(target)) return; const rect=target.getBoundingClientRect(); const before = (e.clientY-rect.top) < rect.height/2; before ? grid.insertBefore(placeholder, target) : grid.insertBefore(placeholder, target.nextSibling); }
-  function onDrop(e){ e.preventDefault(); if(!placeholder||!dragging) return; placeholder.replaceWith(dragging); dragging.classList.remove('dragging'); dragging=null; placeholder=null; persist(); }
-  function onDragEnd(){ if(placeholder && dragging){ placeholder.replaceWith(dragging); } dragging?.classList.remove('dragging'); dragging=null; placeholder=null; persist(); }
-  function persist(){ const ids=$$('#'+grid.id+' > [data-widget-id]').map(x=>x.getAttribute('data-widget-id')); state[orderKey]=ids; save(); }
-  $$('#'+grid.id+' > [data-widget-id]').forEach(el=>{
+  let dragging = null, placeholder = null;
+  function onDragStart(e) {
+    const el = e.currentTarget; dragging = el; el.classList.add('dragging'); e.dataTransfer.effectAllowed = 'move'; placeholder = document.createElement('div'); placeholder.className = 'placeholder'; placeholder.style.gridColumn = el.style.gridColumn || 'span 1'; el.after(placeholder); }
+  function onDragOver(e) { e.preventDefault(); const target = e.target.closest('[data-widget-id]'); if (!target || target === dragging || !grid.contains(target)) return; const rect = target.getBoundingClientRect(); const before = (e.clientY - rect.top) < rect.height / 2; before ? grid.insertBefore(placeholder, target) : grid.insertBefore(placeholder, target.nextSibling); }
+  function onDrop(e) { e.preventDefault(); if (!placeholder || !dragging) return; placeholder.replaceWith(dragging); dragging.classList.remove('dragging'); dragging = null; placeholder = null; persist(); }
+  function onDragEnd() { if (placeholder && dragging) { placeholder.replaceWith(dragging); } dragging?.classList.remove('dragging'); dragging = null; placeholder = null; persist(); }
+  function persist() { const ids = $$('#' + grid.id + ' > [data-widget-id]').map(x => x.getAttribute('data-widget-id')); state[orderKey] = ids; save(); }
+  $$('#' + grid.id + ' > [data-widget-id]').forEach(el => {
     el.addEventListener('dragstart', onDragStart); el.addEventListener('dragover', onDragOver); el.addEventListener('drop', onDrop); el.addEventListener('dragend', onDragEnd);
   });
 }


### PR DESCRIPTION
## Summary
- add shared `dom-utils` module exporting `h`, `$`, `$$`, and `clamp`
- refactor app, charts, and widgets to use new helpers
- pass `state` management explicitly into widget helpers to eliminate circular references

## Testing
- ⚠️ `npm test` *(jest: not found)*
- ⚠️ `npm install --no-audit --no-fund jest` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adab56a678832bb8ebcb9581a851ec