### PR TITLE
Add Jest dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "jest": "^29.x"
   }
 }


### PR DESCRIPTION
## Summary
- add jest devDependency with version ^29.x

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adad031bfc832b90acc2273dcd9c61