### PR TITLE
feat: support widget columns

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -848,17 +848,23 @@ function emptyNotice(){ return h('div',{class:'panel p4'}, h('div',{class:'muted
 function buildGrid(orderKey, dash, gridId){
   ensureDashOrder(dash, orderKey);
   const cols = clamp(state.ui.colCount?.[dash] || 3, 1, 6);
-  const grid=h('div',{class:'grid',id:gridId,style:{gridTemplateColumns:`repeat(${cols}, minmax(0,1fr))`}});
-  const list=(state[orderKey]||[]);
+  const grid = h('div',{class:'grid',id:gridId,style:{gridTemplateColumns:`repeat(${cols}, minmax(0,1fr))`}});
+  const list = (state[orderKey]||[]);
+  if(!list.length){
+    grid.appendChild(emptyNotice());
+    return grid;
+  }
+  const colEls = Array.from({length:cols}, (_,i)=>h('div',{class:'grid','data-col':String(i+1)}));
   for(const id of list){
     const meta=(WidgetRegistry && WidgetRegistry[id])? WidgetRegistry[id] : null;
     if(!meta) continue;
     const built = meta.build();
+    const col = clamp(state.widgetCol[id] || 1, 1, cols);
     const el = widget(id, built, state.widgetSize[id]||meta.size||1, state.widgetHeightMode[id]||'auto', {state});
-    if (state.ui.customizing===dash) addWidgetControls(el, id, orderKey, {state, save, render, configureWidget});
-    grid.appendChild(el);
+    if (state.ui.customizing===dash) addWidgetControls(el, id, orderKey, dash, {state, save, render, configureWidget});
+    colEls[col-1].appendChild(el);
   }
-  if(!grid.children.length) grid.appendChild(emptyNotice());
+  colEls.forEach(c=>grid.appendChild(c));
   setTimeout(()=> enableDrag(grid, orderKey, {state, save}), 0);
   return grid;
 }

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -1,4 +1,4 @@
-import {h, $, $$, clamp} from './dom-utils.js';
+import {h, clamp} from './dom-utils.js';
 export function widget(id, content, size, heightMode, {state}) {
   const el = h('section', {
     class: 'panel p4 drag',
@@ -19,9 +19,11 @@ export function widget(id, content, size, heightMode, {state}) {
   return el;
 }
 
-export function addWidgetControls(wrapper, id, orderKey, {state, save, render, configureWidget}) {
+export function addWidgetControls(wrapper, id, orderKey, dash, {state, save, render, configureWidget}) {
   const size = state.widgetSize[id] || 1;
   const hmode = state.widgetHeightMode[id] || 'auto';
+  const cols = clamp(state.ui.colCount?.[dash] || 3, 1, 6);
+  const curCol = clamp(state.widgetCol[id] || 1, 1, cols);
   const row = h('div', { style: 'display:flex;gap:8px;justify-content:flex-end;margin-bottom:6px;align-items:center;' },
     h('div', { class: 'sizepick' },
       ...[1, 2, 3, 4, 5, 6].map(n => h('button', { 'aria-pressed': String(size === n), onclick: () => { state.widgetSize[id] = n; save(); wrapper.style.gridColumn = 'span ' + n; } }, String(n)))
@@ -33,6 +35,11 @@ export function addWidgetControls(wrapper, id, orderKey, {state, save, render, c
     ),
     h('div', { class: 'field', style: 'width:110px;' + (hmode === 'fixed' ? '' : 'display:none;') }, h('label', null, 'Pixels'),
       h('input', { type: 'number', value: String(state.widgetFixedH[id] || 320), oninput: e => { state.widgetFixedH[id] = e.target.value; save(); render(); } })
+    ),
+    h('div', { class: 'field', style: 'width:90px;' }, h('label', null, 'Column'),
+      h('select', { onchange: e => { state.widgetCol[id] = Number(e.target.value); save(); render(); } },
+        ...Array.from({length: cols}, (_,i)=> h('option',{ value:String(i+1), selected: curCol===i+1?'selected':null }, String(i+1)))
+      )
     ),
     h('button', { class: 'btn tiny', onclick: () => configureWidget(id) }, 'Configure'),
     h('button', { class: 'btn tiny', onclick: () => { state[orderKey] = state[orderKey].filter(x => x !== id); save(); render(); } }, 'Remove')
@@ -46,11 +53,28 @@ export function enableDrag(container, orderKey, {state, save}) {
   let dragging = null, placeholder = null;
   function onDragStart(e) {
     const el = e.currentTarget; dragging = el; el.classList.add('dragging'); e.dataTransfer.effectAllowed = 'move'; placeholder = document.createElement('div'); placeholder.className = 'placeholder'; placeholder.style.gridColumn = el.style.gridColumn || 'span 1'; el.after(placeholder); }
-  function onDragOver(e) { e.preventDefault(); const target = e.target.closest('[data-widget-id]'); if (!target || target === dragging || !grid.contains(target)) return; const rect = target.getBoundingClientRect(); const before = (e.clientY - rect.top) < rect.height / 2; before ? grid.insertBefore(placeholder, target) : grid.insertBefore(placeholder, target.nextSibling); }
+  function onDragOver(e) {
+    e.preventDefault();
+    const target = e.target.closest('[data-widget-id]');
+    if (!target || target === dragging || !grid.contains(target)) return;
+    const rect = target.getBoundingClientRect();
+    const before = (e.clientY - rect.top) < rect.height / 2;
+    const parent = target.parentElement;
+    before ? parent.insertBefore(placeholder, target) : parent.insertBefore(placeholder, target.nextSibling);
+  }
   function onDrop(e) { e.preventDefault(); if (!placeholder || !dragging) return; placeholder.replaceWith(dragging); dragging.classList.remove('dragging'); dragging = null; placeholder = null; persist(); }
   function onDragEnd() { if (placeholder && dragging) { placeholder.replaceWith(dragging); } dragging?.classList.remove('dragging'); dragging = null; placeholder = null; persist(); }
-  function persist() { const ids = $$('#' + grid.id + ' > [data-widget-id]').map(x => x.getAttribute('data-widget-id')); state[orderKey] = ids; save(); }
-  $$('#' + grid.id + ' > [data-widget-id]').forEach(el => {
+  function persist() {
+    const ids = [];
+    grid.querySelectorAll('[data-widget-id]').forEach(el => {
+      ids.push(el.getAttribute('data-widget-id'));
+      const col = Number(el.parentElement.getAttribute('data-col') || 1);
+      state.widgetCol[el.getAttribute('data-widget-id')] = col;
+    });
+    state[orderKey] = ids;
+    save();
+  }
+  grid.querySelectorAll('[data-widget-id]').forEach(el => {
     el.addEventListener('dragstart', onDragStart); el.addEventListener('dragover', onDragOver); el.addEventListener('drop', onDrop); el.addEventListener('dragend', onDragEnd);
   });
 }


### PR DESCRIPTION
## Summary
- group dashboard widgets by column using `state.widgetCol`
- render each column as its own grid container to avoid row alignment issues
- allow choosing widget column in customization controls

## Testing
- `npm test` *(fails: jest not found; installing deps returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adaeacfdec832b897c840621211dc1