### PR TITLE
Remove widget column tracking and rely on DOM order

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -96,7 +96,6 @@ function seed(){
    widgetSize:{}, widgetHeightMode:{}, widgetFixedH:{},
    // NEW:
    widgetCfg:{},
-   widgetCol:{},            // widgetId -> column index (1..N)
    cardOrder:[]            // array of card ids for Cards Overview ordering
  };
 }
@@ -119,8 +118,8 @@ function load(){
     // ⬇️ ADD THESE DEFAULTS
     obj.ui.colCount = obj.ui.colCount || { overview:3, credit:3, financials:3 };
     if (obj.ui.ccCardsCols == null) obj.ui.ccCardsCols = 2;
-    obj.widgetCol = obj.widgetCol || {};
     obj.cardOrder = obj.cardOrder || [];
+    delete obj.widgetCol; // migrate: remove legacy column tracking
 
     return obj;
   }catch{
@@ -854,17 +853,14 @@ function buildGrid(orderKey, dash, gridId){
     grid.appendChild(emptyNotice());
     return grid;
   }
-  const colEls = Array.from({length:cols}, (_,i)=>h('div',{class:'grid','data-col':String(i+1)}));
   for(const id of list){
     const meta=(WidgetRegistry && WidgetRegistry[id])? WidgetRegistry[id] : null;
     if(!meta) continue;
     const built = meta.build();
-    const col = clamp(state.widgetCol[id] || 1, 1, cols);
     const el = widget(id, built, state.widgetSize[id]||meta.size||1, state.widgetHeightMode[id]||'auto', {state});
     if (state.ui.customizing===dash) addWidgetControls(el, id, orderKey, dash, {state, save, render, configureWidget});
-    colEls[col-1].appendChild(el);
+    grid.appendChild(el);
   }
-  colEls.forEach(c=>grid.appendChild(c));
   setTimeout(()=> enableDrag(grid, orderKey, {state, save}), 0);
   return grid;
 }

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -22,8 +22,6 @@ export function widget(id, content, size, heightMode, {state}) {
 export function addWidgetControls(wrapper, id, orderKey, dash, {state, save, render, configureWidget}) {
   const size = state.widgetSize[id] || 1;
   const hmode = state.widgetHeightMode[id] || 'auto';
-  const cols = clamp(state.ui.colCount?.[dash] || 3, 1, 6);
-  const curCol = clamp(state.widgetCol[id] || 1, 1, cols);
   const row = h('div', { style: 'display:flex;gap:8px;justify-content:flex-end;margin-bottom:6px;align-items:center;' },
     h('div', { class: 'sizepick' },
       ...[1, 2, 3, 4, 5, 6].map(n => h('button', { 'aria-pressed': String(size === n), onclick: () => { state.widgetSize[id] = n; save(); wrapper.style.gridColumn = 'span ' + n; } }, String(n)))
@@ -35,11 +33,6 @@ export function addWidgetControls(wrapper, id, orderKey, dash, {state, save, ren
     ),
     h('div', { class: 'field', style: 'width:110px;' + (hmode === 'fixed' ? '' : 'display:none;') }, h('label', null, 'Pixels'),
       h('input', { type: 'number', value: String(state.widgetFixedH[id] || 320), oninput: e => { state.widgetFixedH[id] = e.target.value; save(); render(); } })
-    ),
-    h('div', { class: 'field', style: 'width:90px;' }, h('label', null, 'Column'),
-      h('select', { onchange: e => { state.widgetCol[id] = Number(e.target.value); save(); render(); } },
-        ...Array.from({length: cols}, (_,i)=> h('option',{ value:String(i+1), selected: curCol===i+1?'selected':null }, String(i+1)))
-      )
     ),
     h('button', { class: 'btn tiny', onclick: () => configureWidget(id) }, 'Configure'),
     h('button', { class: 'btn tiny', onclick: () => { state[orderKey] = state[orderKey].filter(x => x !== id); save(); render(); } }, 'Remove')
@@ -68,8 +61,6 @@ export function enableDrag(container, orderKey, {state, save}) {
     const ids = [];
     grid.querySelectorAll('[data-widget-id]').forEach(el => {
       ids.push(el.getAttribute('data-widget-id'));
-      const col = Number(el.parentElement.getAttribute('data-col') || 1);
-      state.widgetCol[el.getAttribute('data-widget-id')] = col;
     });
     state[orderKey] = ids;
     save();


### PR DESCRIPTION
## Summary
- drop column selector and `widgetCol` state from widget controls
- simplify drag persistence to save DOM order only
- migrate saved layouts by deleting legacy `widgetCol` data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc40b8da0832b8acde827bd712e90