### PR TITLE
Allow passive false for event listeners requiring preventDefault

### DIFF
--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -4,10 +4,12 @@ export const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
 
 export function h(tag, attrs = {}, ...children) {
   const el = document.createElement(tag);
-  for (const [k, v] of Object.entries(attrs || {})) {
+  const { passive, ...rest } = attrs || {};
+  const listenerOpts = passive === false ? { passive: false } : { passive: true };
+  for (const [k, v] of Object.entries(rest)) {
     if (k === 'class') el.className = v;
     else if (k.startsWith('on') && typeof v === 'function')
-      el.addEventListener(k.slice(2).toLowerCase(), v, { passive: true });
+      el.addEventListener(k.slice(2).toLowerCase(), v, listenerOpts);
     else if (k === 'style' && typeof v === 'object')
       el.setAttribute('style', Object.entries(v).map(([a, b]) => `${a}:${b}`).join(';'));
     else if (v !== false && v != null) el.setAttribute(k, v === true ? '' : v);

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -65,6 +65,9 @@ export function enableDrag(container, orderKey, {state, save}) {
     save();
   }
   grid.querySelectorAll('[data-widget-id]').forEach(el => {
-    el.addEventListener('dragstart', onDragStart); el.addEventListener('dragover', onDragOver); el.addEventListener('drop', onDrop); el.addEventListener('dragend', onDragEnd);
+    el.addEventListener('dragstart', onDragStart);
+    el.addEventListener('dragover', onDragOver, { passive: false });
+    el.addEventListener('drop', onDrop, { passive: false });
+    el.addEventListener('dragend', onDragEnd);
   });
 }


### PR DESCRIPTION
## Summary
- Enable `h` helper to respect `passive: false` for event listeners
- Ensure widget drag handlers disable passive mode so `preventDefault()` works

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adcc116cb4832ba0f9acff2a6a2c15