### PR TITLE
Use inline SVG icons for sidebar controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,14 +30,18 @@
    overflow:hidden;
 }
   .brand{display:flex;align-items:center;gap:10px;margin-bottom:8px}
-  .brand .logo{width:28px;height:28px;border-radius:8px;background:var(--accent);background-size:cover;background-position:center center}
+  .brand .logo{width:28px;height:28px;border-radius:8px;background:var(--accent);color:#fff;display:inline-grid;place-items:center;overflow:hidden}
+  .brand .logo img{width:100%;height:100%;object-fit:cover}
+  .brand .logo svg{width:100%;height:100%;fill:currentColor;display:block}
   .brand .title{font-weight:800;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .collapse-btn{border:1px solid var(--border);background:var(--panel-2);border-radius:10px;padding:6px 8px;cursor:pointer}
+  .collapse-btn{border:1px solid var(--border);background:var(--panel-2);border-radius:10px;padding:6px 8px;cursor:pointer;color:var(--text)}
+  .collapse-btn svg{width:16px;height:16px;fill:currentColor;display:block}
   .nav{display:flex;flex-direction:column;gap:4px;margin-top:8px}
   .nav .item{display:flex;align-items:center;gap:10px;padding:8px 10px;border-radius:12px;cursor:pointer;border:1px solid transparent}
   .nav .item:hover{background:var(--panel-2)}
   .nav .item.active{background:var(--panel-2);border-color:var(--border)}
   .nav .icon{width:26px;height:26px;border-radius:8px;display:inline-grid;place-items:center;background:var(--panel-2);font-size:12px}
+  .nav .icon svg{width:16px;height:16px;display:block;fill:currentColor}
   .spacer{flex:1}
   .foot{display:flex;flex-direction:column;gap:8px}
   .switch{position:relative;width:48px;height:26px;background:var(--panel-2);border:1px solid var(--border);border-radius:999px;cursor:pointer}

--- a/src/app.js
+++ b/src/app.js
@@ -314,6 +314,23 @@ export function configureWidget(id){
 }
 
 /* ---------- App chrome ---------- */
+function chevronLeft(){
+  return h('svg',{viewBox:'0 0 24 24','aria-hidden':'true'},
+    h('path',{d:'M15 19l-7-7 7-7',fill:'none',stroke:'currentColor','stroke-width':'2','stroke-linecap':'round','stroke-linejoin':'round'})
+  );
+}
+function chevronRight(){
+  return h('svg',{viewBox:'0 0 24 24','aria-hidden':'true'},
+    h('path',{d:'M9 5l7 7-7 7',fill:'none',stroke:'currentColor','stroke-width':'2','stroke-linecap':'round','stroke-linejoin':'round'})
+  );
+}
+function defaultLogoSvg(){
+  return h('svg',{viewBox:'0 0 24 24','aria-hidden':'true'},
+    h('rect',{x:'3',y:'10',width:'3',height:'11',rx:'1'}),
+    h('rect',{x:'10',y:'6',width:'3',height:'15',rx:'1'}),
+    h('rect',{x:'17',y:'3',width:'3',height:'18',rx:'1'})
+  );
+}
 function appSidebar(){
   const collapsed = !!state.ui.sidebarCollapsed;
   const item=(id, icon, label)=> h('div',{class:'item '+(state.section===id?'active':''), onclick:()=>{ state.section=id; save(); render(); }},
@@ -322,11 +339,11 @@ function appSidebar(){
   const themeSwitch = h('div',{class:'switch '+(state.theme==='dark'?'on':''), onclick:()=>{ state.theme = state.theme==='dark'?'light':'dark'; save(); render(); }},
     h('div',{class:'knob'})
   );
-  const arrow = collapsed ? '▶' : '◀';
-  const logoStyle = state.logoData ? `background-image:url(${state.logoData}); background-size:cover;` : '';
+  const arrow = collapsed ? chevronRight() : chevronLeft();
+  const logoNode = state.logoData ? h('img',{src:state.logoData,alt:'Logo'}) : defaultLogoSvg();
   return h('aside',{class:'sidebar'},
     h('div',{class:'brand'},
-      h('div',{class:'logo', style:logoStyle}),
+      h('div',{class:'logo'}, logoNode),
       collapsed? null : h('div',{class:'title'}, state.company || 'Company Finance'),
       h('button',{class:'collapse-btn',title: collapsed?'Expand sidebar':'Collapse sidebar', onclick:(e)=>{ e.stopPropagation(); state.ui.sidebarCollapsed=!collapsed; save(); render(); }}, arrow)
     ),


### PR DESCRIPTION
## Summary
- replace sidebar collapse glyphs and bitmap logo with inline SVG assets
- size and color SVG icons via CSS using `currentColor`
- add inline bar-chart SVG as default logo fallback

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adda2d59c0832b82074f9e946c1339