### PR TITLE
feat: unify transition styling with reduced-motion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ chart type, color palette, and more. A sample widget configuration object:
 }
 ```
 
+## Animations
+
+Interactive elements use a shared `--anim-duration` CSS variable to control transition timing.
+Animations are disabled when users enable the `prefers-reduced-motion` setting in their system preferences.
+
 ### Data Storage
 
 All preferences and financial data are stored in the browser's `localStorage`

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     --bg:#F7F8FB; --panel:#FFFFFF; --panel-2:#F3F5F9; --border:#E3E8EF;
     --text:#0B1220; --muted:#5B6474; --muted-2:#7A8596; --accent:#2B73F7; --ring:#9BB8FF;
     --shadow:0 1px 2px rgba(16,24,40,.06), 0 6px 20px rgba(16,24,40,.06);
-    --anim-duration:.2s;
+    --anim-duration:0.2s;
     --radius:16px; --cols-3: 1fr 1.6fr 1fr; --gradient-alpha: .06;
     --content-max: 2200px; --sidebar-w: 264px; --sidebar-w-collapsed: 64px;
   }
@@ -91,7 +91,7 @@
   .toast .muted{font-size:12px;margin-bottom:8px}
   .palette{display:flex;gap:6px;flex-wrap:wrap}
   .swatch{width:28px;height:28px;border-radius:8px;border:1px solid var(--border);cursor:pointer;transition:background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)}
-  @media (prefers-reduced-motion:reduce){
+  @media (prefers-reduced-motion: reduce){
     :root{--anim-duration:0s}
     .card:hover{transform:none}
   }

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     --bg:#F7F8FB; --panel:#FFFFFF; --panel-2:#F3F5F9; --border:#E3E8EF;
     --text:#0B1220; --muted:#5B6474; --muted-2:#7A8596; --accent:#2B73F7; --ring:#9BB8FF;
     --shadow:0 1px 2px rgba(16,24,40,.06), 0 6px 20px rgba(16,24,40,.06);
+    --anim-duration:.2s;
     --radius:16px; --cols-3: 1fr 1.6fr 1fr; --gradient-alpha: .06;
     --content-max: 2200px; --sidebar-w: 264px; --sidebar-w-collapsed: 64px;
   }
@@ -32,22 +33,22 @@
   .brand{display:flex;align-items:center;gap:10px;margin-bottom:8px}
   .brand .logo{width:28px;height:28px;border-radius:8px;background:var(--accent);background-size:cover;background-position:center center}
   .brand .title{font-weight:800;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-  .collapse-btn{border:1px solid var(--border);background:var(--panel-2);border-radius:10px;padding:6px 8px;cursor:pointer}
+  .collapse-btn{border:1px solid var(--border);background:var(--panel-2);border-radius:10px;padding:6px 8px;cursor:pointer;transition:background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)}
   .nav{display:flex;flex-direction:column;gap:4px;margin-top:8px}
-  .nav .item{display:flex;align-items:center;gap:10px;padding:8px 10px;border-radius:12px;cursor:pointer;border:1px solid transparent}
+  .nav .item{display:flex;align-items:center;gap:10px;padding:8px 10px;border-radius:12px;cursor:pointer;border:1px solid transparent;transition:background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)}
   .nav .item:hover{background:var(--panel-2)}
   .nav .item.active{background:var(--panel-2);border-color:var(--border)}
   .nav .icon{width:26px;height:26px;border-radius:8px;display:inline-grid;place-items:center;background:var(--panel-2);font-size:12px}
   .spacer{flex:1}
   .foot{display:flex;flex-direction:column;gap:8px}
-  .switch{position:relative;width:48px;height:26px;background:var(--panel-2);border:1px solid var(--border);border-radius:999px;cursor:pointer}
-  .switch .knob{position:absolute;top:1px;left:1px;width:24px;height:24px;border:1px solid var(--border);background:var(--panel);border-radius:50%;transition:left .18s}
+  .switch{position:relative;width:48px;height:26px;background:var(--panel-2);border:1px solid var(--border);border-radius:999px;cursor:pointer;transition:background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)}
+  .switch .knob{position:absolute;top:1px;left:1px;width:24px;height:24px;border:1px solid var(--border);background:var(--panel);border-radius:50%;transition:left var(--anim-duration),background var(--anim-duration),transform var(--anim-duration)}
   .switch.on .knob{left:23px}
   .main{min-height:60vh}
   .header{display:flex;justify-content:space-between;align-items:flex-end;margin-bottom:8px}
   h1{font-size:20px;margin:0;font-weight:800}
   .muted{color:var(--muted);font-size:12px}
-  .btn{background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:12px;padding:8px 12px;cursor:pointer;transition:.12s}
+  .btn{background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:12px;padding:8px 12px;cursor:pointer;transition:background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)}
   .btn:hover{background:var(--panel-2)}
   .btn.primary{background:var(--accent);border-color:var(--accent);color:#fff}
   .btn.tiny{padding:6px 8px;border-radius:10px;font-size:12px}
@@ -63,7 +64,7 @@
   .kpi .value{font-size:20px;font-weight:700;margin-top:6px}
   .title{font-weight:700;margin-bottom:8px;font-size:14px}
   .field label{font-size:12px;color:var(--muted);display:block}
-  .field input,.field select,.field textarea{width:100%;padding:10px 12px;border-radius:10px;border:1px solid var(--border);background:var(--panel);color:var(--text);outline:none}
+  .field input,.field select,.field textarea{width:100%;padding:10px 12px;border-radius:10px;border:1px solid var(--border);background:var(--panel);color:var(--text);outline:none;transition:background var(--anim-duration),color var(--anim-duration),box-shadow var(--anim-duration)}
   .field input:hover,.field select:hover,.field textarea:hover{background:var(--panel-2)}
   .field input:focus,.field select:focus,.field textarea:focus{box-shadow:0 0 0 3px var(--ring)}
   .table{width:100%;border-collapse:collapse;font-size:13px}
@@ -71,7 +72,7 @@
   .drag{cursor:grab}
   .drag.dragging{opacity:.6}
   .placeholder{border:2px dashed var(--border);border-radius:var(--radius);min-height:80px}
-  .card{position:relative;border-radius:var(--radius);border:1px solid var(--border);padding:16px;background:var(--panel);box-shadow:var(--shadow);transition:transform .12s}
+  .card{position:relative;border-radius:var(--radius);border:1px solid var(--border);padding:16px;background:var(--panel);box-shadow:var(--shadow);transition:background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)}
   .card:hover{transform:translateY(-1px)}
   .badge{position:absolute;top:8px;right:8px;font-size:11px;padding:4px 8px;border-radius:999px}
   .warn{background:#FFF3D6;color:#A66B00}
@@ -81,15 +82,19 @@
   .cal .dow{text-align:center;color:var(--muted);font-size:11px}
   .dot{width:8px;height:8px;border-radius:9999px;display:inline-block;margin-right:4px}
   .customize-bar{position:sticky;top:12px;z-index:5;background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:10px 12px}
-  .chip{display:inline-flex;align-items:center;gap:6px;background:var(--panel-2);color:var(--text);padding:6px 8px;border-radius:999px;border:1px solid var(--border);font-size:12px}
+  .chip{display:inline-flex;align-items:center;gap:6px;background:var(--panel-2);color:var(--text);padding:6px 8px;border-radius:999px;border:1px solid var(--border);font-size:12px;transition:background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)}
   .sizepick{display:inline-flex;border:1px solid var(--border);border-radius:8px;overflow:hidden}
-  .sizepick button{padding:4px 8px;background:transparent;border:0;cursor:pointer;font-size:12px}
+  .sizepick button{padding:4px 8px;background:transparent;border:0;cursor:pointer;font-size:12px;transition:background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)}
   .sizepick button[aria-pressed="true"]{background:var(--accent);color:#fff}
   .toast{position:fixed;right:16px;bottom:16px;background:var(--panel);color:var(--text);border:1px solid var(--border);box-shadow:var(--shadow);border-radius:12px;padding:12px 14px;z-index:9999;max-width:360px}
   .toast h3{margin:0 0 4px;font-size:14px}
   .toast .muted{font-size:12px;margin-bottom:8px}
   .palette{display:flex;gap:6px;flex-wrap:wrap}
-  .swatch{width:28px;height:28px;border-radius:8px;border:1px solid var(--border);cursor:pointer}
+  .swatch{width:28px;height:28px;border-radius:8px;border:1px solid var(--border);cursor:pointer;transition:background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)}
+  @media (prefers-reduced-motion:reduce){
+    :root{--anim-duration:0s}
+    .card:hover{transform:none}
+  }
 </style>
 </head>
 <body>

--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -14,7 +14,7 @@ export function h(tag, attrs = {}, ...children) {
       el.setAttribute('style', Object.entries(v).map(([a, b]) => `${a}:${b}`).join(';'));
     else if (v !== false && v != null) el.setAttribute(k, v === true ? '' : v);
   }
-  if (rest.class && rest.class.split(/\s+/).some(c => ['btn','item','card','collapse-btn','chip','swatch','knob'].includes(c))) {
+  if (rest.class && rest.class.split(/\s+/).some(c => ['btn','item','card','collapse-btn','chip','swatch','switch','knob'].includes(c))) {
     const t = 'background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)';
     el.style.transition = el.style.transition ? el.style.transition + ',' + t : t;
   }

--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -14,6 +14,10 @@ export function h(tag, attrs = {}, ...children) {
       el.setAttribute('style', Object.entries(v).map(([a, b]) => `${a}:${b}`).join(';'));
     else if (v !== false && v != null) el.setAttribute(k, v === true ? '' : v);
   }
+  if (rest.class && rest.class.split(/\s+/).some(c => ['btn','item','card','collapse-btn','chip','swatch','knob'].includes(c))) {
+    const t = 'background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)';
+    el.style.transition = el.style.transition ? el.style.transition + ',' + t : t;
+  }
   for (const c of children.flat()) {
     if (c == null || c === false) continue;
     if (typeof c === 'string' || typeof c === 'number' || typeof c === 'boolean')

--- a/tests/dom-utils.test.js
+++ b/tests/dom-utils.test.js
@@ -1,0 +1,47 @@
+const path = require('path');
+const fs = require('fs');
+const vm = require('vm');
+const esbuild = require('esbuild');
+
+describe('h helper', () => {
+  let h;
+
+  beforeAll(() => {
+    global.document = {
+      createElement(tag) {
+        return {
+          tagName: tag,
+          children: [],
+          style: {},
+          className: '',
+          setAttribute(k, v) {
+            if (k === 'class') this.className = v;
+            else if (k === 'style') {
+              v.split(';').forEach(p => {
+                if (!p) return;
+                const [a, b] = p.split(':');
+                this.style[a.trim()] = b.trim();
+              });
+            }
+          },
+          appendChild(child) { this.children.push(child); return child; },
+          addEventListener() {}
+        };
+      },
+      createTextNode(text) { return { nodeType: 3, textContent: String(text) }; }
+    };
+    const abs = path.resolve(__dirname, '../src/dom-utils.js');
+    const source = fs.readFileSync(abs, 'utf8');
+    const { code } = esbuild.transformSync(source, { loader: 'js', format: 'cjs', sourcefile: abs });
+    const module = { exports: {} };
+    vm.runInNewContext(code, { module, exports: module.exports, require, document: global.document });
+    h = module.exports.h;
+  });
+
+  test('adds transition styles for interactive classes', () => {
+    const el = h('button', { class: 'btn' }, 'Hi');
+    expect(el.style.transition).toBe('background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)');
+  });
+});
+
+

--- a/tests/dom-utils.test.js
+++ b/tests/dom-utils.test.js
@@ -38,8 +38,11 @@ describe('h helper', () => {
     h = module.exports.h;
   });
 
-  test('adds transition styles for interactive classes', () => {
-    const el = h('button', { class: 'btn' }, 'Hi');
+  test.each([
+    ['button', 'btn'],
+    ['div', 'switch']
+  ])('adds transition styles for %s.%s', (tag, cls) => {
+    const el = h(tag, { class: cls }, 'Hi');
     expect(el.style.transition).toBe('background var(--anim-duration),color var(--anim-duration),transform var(--anim-duration)');
   });
 });


### PR DESCRIPTION
## Summary
- add `--anim-duration` CSS variable and apply consistent transitions to buttons, nav items, cards and other interactive components
- honor `prefers-reduced-motion` by zeroing animation duration and disabling hover lift
- ensure `h()` helper attaches transition styles to dynamically created elements and add tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adda2dc1b4832b938cc869df93f88a