### PR TITLE
feat: add configurable chart easing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ chart type, color palette, and more. A sample widget configuration object:
 
 Chart animations are tunable via **Chart animation (ms, 0=off)** in settings. The duration controls bar and pie chart growth and is disabled automatically when the browser reports `prefers-reduced-motion`.
 
+Both `barChart` and `pieChart` also accept an `easing` option for custom animation curves. By default, animations use an `easeOutCubic` easing function.
+
 ### Data Storage
 
 All preferences and financial data are stored in the browser's `localStorage`

--- a/src/charts.js
+++ b/src/charts.js
@@ -1,6 +1,7 @@
 import {h} from './dom-utils.js';
+import {easeOutCubic} from './easing.js';
 
-export function barChart(items,{colors=[],valueSuffix='',currency=false,yMin=null,yMax=null,duration=300}={}){
+export function barChart(items,{colors=[],valueSuffix='',currency=false,yMin=null,yMax=null,duration=300,easing=easeOutCubic}={}){
   if(!items||!items.length) return h('div',{class:'muted'},'No data');
   const W=720,H=200,P=28,G=12,N=items.length,BAR=(W-P*2-(N-1)*G)/Math.max(1,N);
   let vals=items.map(i=>Number(i.value)||0);
@@ -32,8 +33,9 @@ export function barChart(items,{colors=[],valueSuffix='',currency=false,yMin=nul
     const start=Date.now();
     function frame(){
       const t=Math.min((Date.now()-start)/duration,1);
+      const p=easing(t);
       bars.forEach(b=>{
-        const h=b.bh*t;
+        const h=b.bh*p;
         b.rect.setAttribute('height',h);
         b.rect.setAttribute('y',baseY-h);
         b.top.setAttribute('y',baseY-h-4);
@@ -45,7 +47,7 @@ export function barChart(items,{colors=[],valueSuffix='',currency=false,yMin=nul
   return g;
 }
 
-export function pieChart(items,{colors=[],duration=300}={}){
+export function pieChart(items,{colors=[],duration=300,easing=easeOutCubic}={}){
   if(!items||!items.length) return h('div',{class:'muted'},'No data');
   const W=220,H=220,R=90,CX=W/2,CY=H/2;
   const total=items.reduce((s,i)=>s+(Number(i.value)||0),0)||1;
@@ -70,8 +72,9 @@ export function pieChart(items,{colors=[],duration=300}={}){
     const start=Date.now();
     function frame(){
       const t=Math.min((Date.now()-start)/duration,1);
+      const p=easing(t);
       slices.forEach(s=>{
-        const a=s.start+(s.end-s.start)*t;
+        const a=s.start+(s.end-s.start)*p;
         const x0=CX+R*Math.cos(s.start), y0=CY+R*Math.sin(s.start);
         const x1=CX+R*Math.cos(a), y1=CY+R*Math.sin(a);
         const large=(a-s.start)>Math.PI?1:0;

--- a/src/easing.js
+++ b/src/easing.js
@@ -1,0 +1,3 @@
+export function easeOutCubic(t){
+  return 1 - Math.pow(1 - t, 3);
+}

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -78,4 +78,22 @@ describe('chart animations', () => {
     const d = g.children[0].attributes.d;
     expect(/A 90 90 0 0 1 20(?:\.0+)? 110/.test(d)).toBe(true);
   });
+
+  test('barChart applies easing function', () => {
+    const origRAF = global.requestAnimationFrame;
+    const origNow = Date.now;
+    Date.now = () => 0;
+    let called = false;
+    global.requestAnimationFrame = fn => { if(!called){ called = true; fn(); } };
+    cache.delete(path.resolve(__dirname,'..','src/charts.js'));
+    const {barChart} = loadModule('src/charts.js');
+    const easing = jest.fn().mockReturnValue(0.25);
+    const g = barChart([{label:'A',value:10}],{duration:100,easing});
+    const rect = g.children[0];
+    expect(easing).toHaveBeenCalledWith(0);
+    expect(rect.attributes.height).toBe('36');
+    expect(rect.attributes.y).toBe('136');
+    global.requestAnimationFrame = origRAF;
+    Date.now = origNow;
+  });
 });


### PR DESCRIPTION
## Summary
- add `easeOutCubic` helper and import into charts
- allow bar and pie charts to accept configurable easing functions
- test and document easing option for chart animations

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adedb86cc0832bafad3cdd6c8a1501