### PR TITLE
feat: animate sidebar collapse

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -387,7 +387,7 @@ function appSidebar(){
   );
   const arrow = collapsed ? chevronRight() : chevronLeft();
   const logoNode = state.logoData ? h('img',{src:state.logoData,alt:'Logo'}) : defaultLogoSvg();
-  return h('aside',{class:'sidebar'},
+  return h('aside',{class:'sidebar'+(collapsed?' sidebar--collapsed':'')},
     h('div',{class:'brand'},
       h('div',{class:'logo'}, logoNode),
       collapsed? null : h('div',{class:'title'}, state.company || 'Company Finance'),
@@ -1162,8 +1162,7 @@ export function hardRepair(){
 export function render(){
   applyThemeTokens();
   const root=$('#app'); root.innerHTML='';
-  const collapsed = !!state.ui.sidebarCollapsed;
-  const layout=h('div',{class:'layout', style:`grid-template-columns:${collapsed? 'var(--sidebar-w-collapsed)':'var(--sidebar-w)'} 1fr`});
+  const layout=h('div',{class:'layout'});
   layout.appendChild(appSidebar());
   const main=h('div',{class:'main'});
   main.appendChild(appHeader());

--- a/src/styles.css
+++ b/src/styles.css
@@ -21,7 +21,11 @@
 html, body { height: 100% }
 body { margin: 0; background: var(--bg); color: var(--text); font: 14px/1.45 system-ui, -apple-system, Segoe UI, Roboto, Arial, 'Noto Sans' }
 .app { max-width: var(--content-max); margin: 0 auto; padding: 16px 16px 24px }
-.layout { display: grid; gap: 16px }
+.layout {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: auto 1fr;
+}
 .sidebar {
   background: var(--panel);
   border: 1px solid var(--border);
@@ -34,7 +38,10 @@ body { margin: 0; background: var(--bg); color: var(--text); font: 14px/1.45 sys
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  width: var(--sidebar-w);
+  transition: width 0.2s ease;
 }
+.sidebar.sidebar--collapsed { width: var(--sidebar-w-collapsed) }
 .brand { display: flex; align-items: center; gap: 10px; margin-bottom: 8px }
 .brand .logo { width: 28px; height: 28px; border-radius: 8px; background: var(--accent); color: #fff; display: inline-grid; place-items: center; overflow: hidden }
 .brand .logo img { width: 100%; height: 100%; object-fit: cover }

--- a/tests/ui.interactions.test.js
+++ b/tests/ui.interactions.test.js
@@ -55,6 +55,7 @@ function loadModule(relPath){
   let finalCode = code;
   if(absPath.endsWith(path.join('src','app.js'))){
     finalCode += '\nmodule.exports.applyThemeTokens = applyThemeTokens;';
+    finalCode += '\nmodule.exports._appSidebar = appSidebar;';
   }
   const module = {exports:{}};
   const dirname = path.dirname(absPath);
@@ -107,5 +108,17 @@ describe('addWidgetControls', () => {
     removeBtn.dispatchEvent({type:'click'});
     expect(state.order).toEqual([]);
     expect(render).toHaveBeenCalled();
+  });
+});
+
+describe('sidebar collapse', () => {
+  test('toggles collapsed class', () => {
+    const {state, _appSidebar} = loadModule('src/app.js');
+    state.ui.sidebarCollapsed = false;
+    let sidebar = _appSidebar();
+    expect(sidebar.className.includes('sidebar--collapsed')).toBe(false);
+    state.ui.sidebarCollapsed = true;
+    sidebar = _appSidebar();
+    expect(sidebar.className.includes('sidebar--collapsed')).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- add width transition for sidebar with `.sidebar--collapsed` modifier
- toggle sidebar collapse via class instead of inline grid widths
- test sidebar collapse class

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aef71be324832bb2a7f8a3c162f3a9