### PR TITLE
feat: make animation speed configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ chart type, color palette, and more. A sample widget configuration object:
 
 Chart animations are tunable via **Chart animation (ms, 0=off)** in settings. The duration controls bar and pie chart growth and is disabled automatically when the browser reports `prefers-reduced-motion`.
 
+General interface animations can also be customized. **Animation speed** lets you choose fast, normal, slow or completely disable transitions, and it honors the browser's `prefers-reduced-motion` setting.
+
 Both `barChart` and `pieChart` also accept an `easing` option for custom animation curves. By default, animations use an `easeOutCubic` easing function.
 
 ### Data Storage

--- a/src/app.js
+++ b/src/app.js
@@ -109,6 +109,13 @@ function applyThemeTokens(){
   root.style.setProperty('--radius', (state.ui?.radiusPx || 16) + 'px');
   root.style.setProperty('--cols-3', `1fr ${state.ui?.centerWeight || 1.6}fr 1fr`);
   root.style.setProperty('--gradient-alpha', String(state.ui?.gradientAlpha ?? 0.06));
+  const anim=state.ui?.anim;
+  const body=document.body;
+  if(anim && anim!=='normal'){
+    if(body.dataset) body.dataset.anim=anim; else body.setAttribute('data-anim',anim);
+  }else{
+    if(body.dataset) delete body.dataset.anim; else body.removeAttribute && body.removeAttribute('data-anim');
+  }
 }
 
 /* ---------- Storage & State ---------- */
@@ -126,6 +133,7 @@ function seed(){
     sidebarCollapsed:false, centerWeight:1.6, gradientAlpha:.06, radiusPx:16,
     customizing:null, ccDraft:{}, finDraft:{}, histFilter:{mode:'selected',from:'',to:''},
     companyDraft:'',
+    anim:'normal',
     chartAnimMs:300,
     // NEW:
     fullWidth:false,
@@ -1110,9 +1118,12 @@ function settingsSection(){
           h('option',{value:'compact'},'Compact')
         )
       ); })(),
-      (function(){ const id=uid(); return h('div',{class:'field'}, h('label',{for:id},'Animations'),
-        h('select',{id,onchange:e=>{ document.body.dataset.anim=e.target.value; }},
-          h('option',{value:'on'},'On'), h('option',{value:'off'},'Off')
+      (function(){ const id=uid(); return h('div',{class:'field'}, h('label',{for:id},'Animation speed'),
+        h('select',{id,onchange:e=>{ state.ui.anim=e.target.value; save(); document.body.dataset.anim=e.target.value; }},
+          h('option',{value:'fast',selected:state.ui.anim==='fast'?'selected':null},'Fast'),
+          h('option',{value:'normal',selected:!state.ui.anim||state.ui.anim==='normal'?'selected':null},'Normal'),
+          h('option',{value:'slow',selected:state.ui.anim==='slow'?'selected':null},'Slow'),
+          h('option',{value:'off',selected:state.ui.anim==='off'?'selected':null},'Off')
         )
       ); })(),
       (function(){ const id=uid(); return h('div',{class:'field'}, h('label',{for:id},'Number formatting (thousands)'),

--- a/src/charts.js
+++ b/src/charts.js
@@ -1,7 +1,13 @@
 import {h} from './dom-utils.js';
 import {easeOutCubic} from './easing.js';
 
-export function barChart(items,{colors=[],valueSuffix='',currency=false,yMin=null,yMax=null,duration=300,easing=easeOutCubic}={}){
+function baseDuration(){
+  if(typeof window==='undefined' || !window.getComputedStyle) return 150;
+  const v=parseFloat(window.getComputedStyle(document.body).getPropertyValue('--anim-normal'));
+  return isNaN(v)?150:v;
+}
+
+export function barChart(items,{colors=[],valueSuffix='',currency=false,yMin=null,yMax=null,duration=baseDuration()*2,easing=easeOutCubic}={}){
   if(!items||!items.length) return h('div',{class:'muted'},'No data');
   const W=720,H=200,P=28,G=12,N=items.length,BAR=(W-P*2-(N-1)*G)/Math.max(1,N);
   let vals=items.map(i=>Number(i.value)||0);
@@ -47,7 +53,7 @@ export function barChart(items,{colors=[],valueSuffix='',currency=false,yMin=nul
   return g;
 }
 
-export function pieChart(items,{colors=[],duration=300,easing=easeOutCubic}={}){
+export function pieChart(items,{colors=[],duration=baseDuration()*2,easing=easeOutCubic}={}){
   if(!items||!items.length) return h('div',{class:'muted'},'No data');
   const W=220,H=220,R=90,CX=W/2,CY=H/2;
   const total=items.reduce((s,i)=>s+(Number(i.value)||0),0)||1;

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,6 +16,15 @@
   --content-max: 2200px;
   --sidebar-w: 264px;
   --sidebar-w-collapsed: 64px;
+  --anim-fast: 120ms;
+  --anim-normal: 150ms;
+  --anim-slow: 180ms;
+}
+body[data-anim='fast'] { --anim-fast: 80ms; --anim-normal: 120ms; --anim-slow: 150ms }
+body[data-anim='slow'] { --anim-fast: 150ms; --anim-normal: 200ms; --anim-slow: 250ms }
+body[data-anim='off'] { --anim-fast: 0ms; --anim-normal: 0ms; --anim-slow: 0ms }
+@media (prefers-reduced-motion: reduce) {
+  body { --anim-fast: 0ms !important; --anim-normal: 0ms !important; --anim-slow: 0ms !important }
 }
 * { box-sizing: border-box }
 html, body { height: 100% }
@@ -51,17 +60,17 @@ body { margin: 0; background: var(--bg); color: var(--text); font: 14px/1.45 sys
 .spacer { flex: 1 }
 .foot { display: flex; flex-direction: column; gap: 8px }
 .switch { position: relative; width: 48px; height: 26px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 999px; cursor: pointer }
-.switch .knob { position: absolute; top: 1px; left: 1px; width: 24px; height: 24px; border: 1px solid var(--border); background: var(--panel); border-radius: 50%; transition: left .18s }
+.switch .knob { position: absolute; top: 1px; left: 1px; width: 24px; height: 24px; border: 1px solid var(--border); background: var(--panel); border-radius: 50%; transition: left var(--anim-slow) }
 .switch.on .knob { left: 23px }
 .main { min-height: 60vh }
 .header { display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 8px }
 h1 { font-size: 20px; margin: 0; font-weight: 800 }
 .muted { color: var(--muted); font-size: 12px }
-.btn { background: var(--panel); color: var(--text); border: 1px solid var(--border); border-radius: 12px; padding: 8px 12px; cursor: pointer; transition: .12s }
+.btn { background: var(--panel); color: var(--text); border: 1px solid var(--border); border-radius: 12px; padding: 8px 12px; cursor: pointer; transition: var(--anim-fast) }
 .btn:hover { background: var(--panel-2) }
 .btn.primary { background: var(--accent); border-color: var(--accent); color: #fff }
 .btn.tiny { padding: 6px 8px; border-radius: 10px; font-size: 12px }
-.panel { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); transition: background .15s, box-shadow .15s }
+.panel { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); transition: background var(--anim-normal), box-shadow var(--anim-normal) }
 .panel:hover { background: var(--panel-2); box-shadow: var(--shadow-hover) }
 .p4 { padding: 14px }
 .grid { display: grid; gap: 14px; grid-auto-flow: dense; grid-auto-rows: minmax(0, max-content) }
@@ -82,7 +91,7 @@ h1 { font-size: 20px; margin: 0; font-weight: 800 }
 .drag { cursor: grab }
 .drag.dragging { opacity: .6 }
 .placeholder { border: 2px dashed var(--border); border-radius: var(--radius); min-height: 80px }
-.card { position: relative; border-radius: var(--radius); border: 1px solid var(--border); padding: 16px; background: var(--panel); box-shadow: var(--shadow); transition: transform .12s, background .15s, box-shadow .15s }
+.card { position: relative; border-radius: var(--radius); border: 1px solid var(--border); padding: 16px; background: var(--panel); box-shadow: var(--shadow); transition: transform var(--anim-fast), background var(--anim-normal), box-shadow var(--anim-normal) }
 .card:hover { transform: translateY(-1px); background: var(--panel-2); box-shadow: var(--shadow-hover) }
 .badge { position: absolute; top: 8px; right: 8px; font-size: 11px; padding: 4px 8px; border-radius: 999px }
 .warn { background: #FFF3D6; color: #A66B00 }

--- a/tests/ui.interactions.test.js
+++ b/tests/ui.interactions.test.js
@@ -16,8 +16,9 @@ function createStyle(){
   });
 }
 class Element {
-  constructor(tag){ this.tagName=tag; this.children=[]; this.attributes={}; this.style=createStyle(); this.eventListeners={}; this.parentNode=null; this.className=''; }
-  setAttribute(k,v){ this.attributes[k]=String(v); if(k==='class') this.className=String(v); }
+  constructor(tag){ this.tagName=tag; this.children=[]; this.attributes={}; this.style=createStyle(); this.eventListeners={}; this.parentNode=null; this.className=''; this.dataset={}; }
+  setAttribute(k,v){ this.attributes[k]=String(v); if(k==='class') this.className=String(v); if(k.startsWith('data-')) this.dataset[k.slice(5)]=String(v); }
+  removeAttribute(k){ delete this.attributes[k]; if(k==='class') this.className=''; if(k.startsWith('data-')) delete this.dataset[k.slice(5)]; }
   appendChild(child){ if (typeof child==='string') child=new TextNode(child); child.parentNode=this; this.children.push(child); return child; }
   prepend(child){ if (typeof child==='string') child=new TextNode(child); child.parentNode=this; this.children.unshift(child); return child; }
   addEventListener(type,handler){ (this.eventListeners[type]=this.eventListeners[type]||[]).push(handler); }
@@ -107,5 +108,14 @@ describe('addWidgetControls', () => {
     removeBtn.dispatchEvent({type:'click'});
     expect(state.order).toEqual([]);
     expect(render).toHaveBeenCalled();
+  });
+});
+
+describe('animation speed setting', () => {
+  test('applyThemeTokens applies state.ui.anim', () => {
+    const {state, applyThemeTokens} = loadModule('src/app.js');
+    state.ui.anim = 'fast';
+    applyThemeTokens();
+    expect(document.body.dataset.anim).toBe('fast');
   });
 });


### PR DESCRIPTION
## Summary
- add CSS variables for animation timings and honor reduced-motion
- allow users to set global animation speed (fast/normal/slow/off)
- derive chart animation duration from CSS variables

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aef71dcf3c832b9e805ae9fdc065b5