### PR TITLE
chore(ci): add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm test
+      - run: npm run build

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The compiled assets will be output to the `dist/` folder.
 npm test
 ```
 
+## Continuous Integration
+
+GitHub Actions runs `npm ci`, `npm test`, and `npm run build` on every push and pull request. Dependency caching speeds up repeated builds.
+
 ## Configuration
 
 Widgets and dashboard panels can be customized through the in-app settings.


### PR DESCRIPTION
## Summary
- run npm ci, npm test, and npm run build on pushes and PRs with caching
- document the continuous integration pipeline in the README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aef71f0200832bbb614c49e55498ef