### PR TITLE
docs: add JSDoc configuration and deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Build Docs
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run docs
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ The compiled assets will be output to the `dist/` folder.
 npm test
 ```
 
+## Documentation
+
+```bash
+npm run docs
+```
+
+Open `docs/index.html` in your browser to preview the generated API docs.
+
 ## Configuration
 
 Widgets and dashboard panels can be customized through the in-app settings.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>API Documentation</title>
+</head>
+<body>
+  <h1>API Documentation</h1>
+  <p>Generated with JSDoc.</p>
+</body>
+</html>

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,11 @@
+{
+  "source": {
+    "include": ["src", "utils.js"],
+    "includePattern": ".js$",
+    "excludePattern": "(node_modules|docs)"
+  },
+  "opts": {
+    "destination": "docs",
+    "recurse": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "node utils.js",
     "test": "jest",
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "docs": "jsdoc -c jsdoc.json"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
   "devDependencies": {
     "vite": "^5.0.0",
     "jest": "^29.x",
-    "esbuild": "^0.19.0"
+    "esbuild": "^0.19.0",
+    "jsdoc": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add JSDoc config and script
- scaffold docs site and GitHub Pages workflow
- document how to build and preview docs

## Testing
- `npm test`
- `npm run build`
- `npm run docs` *(fails: jsdoc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af04ab6538832ba12592154cf0498d