### PR TITLE
fix: remove default widget hover

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -501,7 +501,7 @@ function ccCardsGridWidget(){
       const bg = card.useGradient!==false ? `linear-gradient(180deg, rgba(${r},${g},${b},${(state.ui.gradientAlpha??.06)}) 0%, rgba(${r},${g},${b},0.00) 100%)` : 'var(--panel)';
       const baseStyle = `border-color:${card.color||'#3b82f6'}; background:${bg}`;
       const overTarget = card.utilTarget!=null && util!=null ? ((util*100)>=Number(card.utilTarget)) : false;
-      const cardBox=h('div',{class:'card',style:baseStyle},
+      const cardBox=h('div',{class:'card hoverable',style:baseStyle},
         overLimit>0? h('div',{class:'badge bad'}, 'Over by '+fmtUSD(overLimit)) : (overTarget? h('div',{class:'badge warn'}, '≥ Target '+card.utilTarget+'%') : null),
         h('div',{style:'display:flex;justify-content:space-between;align-items:center;gap:8px;'},
           h('div',null, h('div',{style:'font-weight:700;font-size:16px;'}, card.name),

--- a/src/styles.css
+++ b/src/styles.css
@@ -62,7 +62,7 @@ h1 { font-size: 20px; margin: 0; font-weight: 800 }
 .btn.primary { background: var(--accent); border-color: var(--accent); color: #fff }
 .btn.tiny { padding: 6px 8px; border-radius: 10px; font-size: 12px }
 .panel { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); transition: background .15s, box-shadow .15s }
-.panel:hover { background: var(--panel-2); box-shadow: var(--shadow-hover) }
+.panel.hoverable:hover { background: var(--panel-2); box-shadow: var(--shadow-hover) }
 .p4 { padding: 14px }
 .grid { display: grid; gap: 14px; grid-auto-flow: dense; grid-auto-rows: minmax(0, max-content) }
 .grid-3 { grid-template-columns: var(--cols-3) }
@@ -83,7 +83,7 @@ h1 { font-size: 20px; margin: 0; font-weight: 800 }
 .drag.dragging { opacity: .6 }
 .placeholder { border: 2px dashed var(--border); border-radius: var(--radius); min-height: 80px }
 .card { position: relative; border-radius: var(--radius); border: 1px solid var(--border); padding: 16px; background: var(--panel); box-shadow: var(--shadow); transition: transform .12s, background .15s, box-shadow .15s }
-.card:hover { transform: translateY(-1px); background: var(--panel-2); box-shadow: var(--shadow-hover) }
+.card.hoverable:hover { transform: translateY(-1px); background: var(--panel-2); box-shadow: var(--shadow-hover) }
 .badge { position: absolute; top: 8px; right: 8px; font-size: 11px; padding: 4px 8px; border-radius: 999px }
 .warn { background: #FFF3D6; color: #A66B00 }
 .bad { background: #FDE2E2; color: #B42318 }


### PR DESCRIPTION
## Summary
- drop default hover styles from panels and cards
- add optional `.hoverable` variant for panels/cards
- use `.hoverable` on credit card overview items

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af0759c910832bae038379e51224cf