### PR TITLE
refactor: centralize uid helper

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-import {h, $, $$, clamp} from './dom-utils.js';
+import {h, $, $$, clamp, uid} from './dom-utils.js';
 import {barChart, pieChart} from './charts.js';
 import {widget, addWidgetControls, enableDrag} from './widgets.js';
 
@@ -7,7 +7,6 @@ window.WidgetRegistry = window.WidgetRegistry || {}; // global
 const WidgetRegistry = window.WidgetRegistry;
 
 /* ---------- Utilities ---------- */
-export const uid=()=>globalThis.crypto?.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)+Date.now().toString(36);
 export const todayISO=()=>new Date().toISOString().slice(0,10);
 export const daysBetween = (a,b) => { const A=new Date(a), B=new Date(b); A.setHours(0,0,0,0); B.setHours(0,0,0,0); return Math.round((B-A)/86400000) };
 export const fmtUSD = (n) => (n==null || isNaN(n) ? '—' : Number(n).toLocaleString(undefined,{style:'currency',currency:'USD',maximumFractionDigits:2}));

--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -1,6 +1,10 @@
 export const $ = (s, el = document) => el.querySelector(s);
 export const $$ = (s, el = document) => Array.from(el.querySelectorAll(s));
 export const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
+export const uid = () =>
+  globalThis.crypto?.randomUUID
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2) + Date.now().toString(36);
 
 export function h(tag, attrs = {}, ...children) {
   const el = document.createElement(tag);

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -1,5 +1,4 @@
-import {h, clamp} from './dom-utils.js';
-const uid = () => globalThis.crypto?.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)+Date.now().toString(36);
+import {h, clamp, uid} from './dom-utils.js';
 export function widget(id, content, size, heightMode, {state}) {
   const el = h('section', {
     class: 'panel p4 drag',

--- a/tests/charts.test.js
+++ b/tests/charts.test.js
@@ -44,7 +44,7 @@ function loadModule(rel){
   const source = fs.readFileSync(abs,'utf8');
   const {code} = esbuild.transformSync(source,{loader:'js',format:'cjs',sourcefile:abs});
   const module = {exports:{}};
-  const context = {module,exports:module.exports,require:p=>p.startsWith('.')?loadModule(path.join(path.dirname(abs),p)):require(p),window,document,localStorage,requestAnimationFrame};
+  const context = {module,exports:module.exports,require:p=>p.startsWith('.')?loadModule(path.join(path.dirname(abs),p)):require(p),window,document,localStorage,requestAnimationFrame,Date};
   vm.runInNewContext(code, context);
   cache.set(abs,module.exports);
   return module.exports;

--- a/tests/dom-utils.test.js
+++ b/tests/dom-utils.test.js
@@ -1,0 +1,23 @@
+const path = require('path');
+const fs = require('fs');
+const vm = require('vm');
+const esbuild = require('esbuild');
+
+function loadDomUtils(){
+  const absPath = path.resolve(__dirname, '..', 'src', 'dom-utils.js');
+  const source = fs.readFileSync(absPath, 'utf8');
+  const {code} = esbuild.transformSync(source, {loader: 'js', format: 'cjs', sourcefile: absPath});
+  const module = {exports: {}};
+  vm.runInNewContext(code, {module, exports: module.exports, require});
+  return module.exports;
+}
+
+describe('uid', () => {
+  test('generates unique strings', () => {
+    const {uid} = loadDomUtils();
+    const a = uid();
+    const b = uid();
+    expect(typeof a).toBe('string');
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
## Summary
- move UID generator to `dom-utils` and import it across modules
- remove duplicate UID implementations
- add tests for the UID helper and ensure chart tests honor stubbed time

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af1126991c832baca6d22b31ec14ea