### PR TITLE
feat: align payment calendar to week

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -891,12 +891,30 @@ function ChangedTodayWidget(){
   })))];
 }
 function PayCalendarWidget(){
-  const latest=latestByCard(); const now=new Date(); const dates=[]; for(let i=0;i<28;i++){ const d=new Date(now); d.setDate(now.getDate()+i); dates.push(d.toISOString().slice(0,10)); }
+  const latest=latestByCard();
+  const start=new Date();
+  start.setDate(start.getDate()-start.getDay());
+  const dates=[];
+  for(let i=0;i<28;i++){
+    const d=new Date(start);
+    d.setDate(start.getDate()+i);
+    dates.push(d.toISOString().slice(0,10));
+  }
   const wrap=h('div',null, sectionTitle('Payment Calendar (next 4 weeks)'), h('div',{class:'cal'}));
-  const grid=wrap.lastChild; grid.appendChild(h('div',{class:'dow'},'Sun'));grid.appendChild(h('div',{class:'dow'},'Mon'));grid.appendChild(h('div',{class:'dow'},'Tue'));grid.appendChild(h('div',{class:'dow'},'Wed'));grid.appendChild(h('div',{class:'dow'},'Thu'));grid.appendChild(h('div',{class:'dow'},'Fri'));grid.appendChild(h('div',{class:'dow'},'Sat'));
+  const grid=wrap.lastChild;
+  grid.appendChild(h('div',{class:'dow'},'Sun'));
+  grid.appendChild(h('div',{class:'dow'},'Mon'));
+  grid.appendChild(h('div',{class:'dow'},'Tue'));
+  grid.appendChild(h('div',{class:'dow'},'Wed'));
+  grid.appendChild(h('div',{class:'dow'},'Thu'));
+  grid.appendChild(h('div',{class:'dow'},'Fri'));
+  grid.appendChild(h('div',{class:'dow'},'Sat'));
+  const offset=start.getDay();
+  for(let i=0;i<offset;i++) grid.appendChild(h('div',{class:'cell'}));
+  const today=todayISO();
   dates.forEach(d=>{
-    const box=h('div',{class:'cell'}, h('div',{class:'muted'}, d));
-    state.cards.forEach(c=>{ const last=latest[c.id]; if(last?.dueDate===d){ const dot=h('span',{class:'dot',style:'background:'+ (c.color||'#3b82f6')}); box.appendChild(h('div',null, dot, ' ', c.name)); } });
+    const box=h('div',{class:'cell'+(d===today?' today':'')}, h('div',{class:'muted'}, d));
+    state.cards.forEach(c=>{ const last=latest[c.id]; if(last?.dueDate===d){ const dot=h('span',{class:'dot',style:'background:'+(c.color||'#3b82f6')}); box.appendChild(h('div',null, dot, ' ', c.name)); } });
     grid.appendChild(box);
   });
   return [wrap];

--- a/src/styles.css
+++ b/src/styles.css
@@ -90,6 +90,7 @@ h1 { font-size: 20px; margin: 0; font-weight: 800 }
 .cal { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 8px }
 .cal .cell { min-height: 84px; border: 1px solid var(--border); border-radius: 12px; padding: 6px; overflow: hidden; background: var(--panel) }
 .cal .dow { text-align: center; color: var(--muted); font-size: 11px }
+.cal .today { border-color: var(--accent); background: var(--panel-2) }
 .dot { width: 8px; height: 8px; border-radius: 9999px; display: inline-block; margin-right: 4px }
 .customize-bar { position: sticky; top: 12px; z-index: 5; background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 10px 12px }
 .chip { display: inline-flex; align-items: center; gap: 6px; background: var(--panel-2); color: var(--text); padding: 6px 8px; border-radius: 999px; border: 1px solid var(--border); font-size: 12px }

--- a/tests/ui.interactions.test.js
+++ b/tests/ui.interactions.test.js
@@ -190,6 +190,21 @@ describe('enableDrag', () => {
   });
 });
 
+describe('PayCalendarWidget', () => {
+  test('starts on Sunday and highlights today', () => {
+    const {PayCalendarWidget, todayISO} = loadModule('src/app.js');
+    const [wrap] = PayCalendarWidget();
+    const grid = wrap.lastChild;
+    const cells = grid.children.filter(c=>c.classList.contains('cell'));
+    const firstDateCell = cells.find(c=>c.children[0]);
+    expect(new Date(firstDateCell.children[0].textContent).getDay()).toBe(0);
+    const today = todayISO();
+    const todayCell = cells.find(c=>c.children[0] && c.children[0].textContent === today);
+    expect(todayCell).toBeDefined();
+    expect(todayCell.classList.contains('today')).toBe(true);
+  });
+});
+
 describe('applyThemeTokens', () => {
   test('updates CSS variables for light and dark modes', () => {
     const {state, applyThemeTokens} = loadModule('src/app.js');


### PR DESCRIPTION
## Summary
- align PayCalendarWidget to start on Sunday and span four weeks
- highlight current day in calendar grid and style `.today` cells
- add unit test for weekly alignment and today highlight

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdoc)*
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af15b23188832b93908aa713d78e83