### PR TITLE
feat: expose dashboard column slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Open `docs/index.html` in your browser to preview the generated API docs.
 ## Configuration
 
 Widgets and dashboard panels can be customized through the in-app settings.
+Dashboard column counts are adjustable in Customize mode via a slider (1–6 columns per dashboard).
 Options include size (1–3 columns), height mode (auto, short, medium, tall, or fixed pixels),
 chart type, color palette, and more. A sample widget configuration object:
 

--- a/src/app.js
+++ b/src/app.js
@@ -449,6 +449,10 @@ function customizeBar(dash, orderKey, gridId){
           h('label',{for:centerId,class:'muted'},'Center column weight'),
           h('input',{id:centerId,type:'range',min:'1.3',max:'1.8',step:'0.1',value:String(state.ui.centerWeight||1.6),oninput:e=>{ state.ui.centerWeight=Number(e.target.value); save(); applyThemeTokens(); }})
         ); })(),
+        (function(){ const colsId=uid(); return h('div',null,
+          h('label',{for:colsId,class:'muted'},'Columns'),
+          h('input',{id:colsId,type:'range',min:'1',max:'6',step:'1',value:String(clamp(state.ui.colCount?.[dash]||3,1,6)),oninput:e=>{ state.ui.colCount[dash]=clamp(Number(e.target.value||3),1,6); save(); render(); }})
+        ); })(),
         h('button',{class:'btn tiny',onclick:()=>{ state[orderKey] = availableForDashboard(dash).slice(); save(); render(); showToast('Reset','Widget list restored for '+dash+'.'); }},'Reset'),
         h('button',{class:'btn tiny',onclick:()=>{ state.ui.customizing=null; save(); render(); }},'Done')
       )
@@ -1121,21 +1125,6 @@ function settingsSection(){
           h('option',{value:'on', selected: state.ui.useGrouping!==false?'selected':null},'On'),
           h('option',{value:'off', selected: state.ui.useGrouping===false?'selected':null},'Off')
         )
-      ); })(),
-      (function(){ const id=uid(); return h('div',{class:'field'}, h('label',{for:id},'Overview columns'),
-        h('input',{id,type:'number',min:'1',max:'6',
-          value:String(state.ui.colCount?.overview || 3),
-          oninput:e=>{ state.ui.colCount.overview = clamp(Number(e.target.value||3),1,6); save(); render(); }})
-      ); })(),
-      (function(){ const id=uid(); return h('div',{class:'field'}, h('label',{for:id},'Credit columns'),
-        h('input',{id,type:'number',min:'1',max:'6',
-          value:String(state.ui.colCount?.credit || 3),
-          oninput:e=>{ state.ui.colCount.credit = clamp(Number(e.target.value||3),1,6); save(); render(); }})
-      ); })(),
-      (function(){ const id=uid(); return h('div',{class:'field'}, h('label',{for:id},'Financials columns'),
-        h('input',{id,type:'number',min:'1',max:'6',
-          value:String(state.ui.colCount?.financials || 3),
-          oninput:e=>{ state.ui.colCount.financials = clamp(Number(e.target.value||3),1,6); save(); render(); }})
       ); })()
     )
   );

--- a/tests/ui.interactions.test.js
+++ b/tests/ui.interactions.test.js
@@ -135,6 +135,24 @@ describe('center column weight slider', () => {
   });
 });
 
+describe('column count control', () => {
+  test('updates grid columns on input', () => {
+    const {state, render} = loadModule('src/app.js');
+    const root = document.createElement('div');
+    root.id = 'app';
+    document.body.appendChild(root);
+    state.section = 'overview';
+    state.ui.customizing = 'overview';
+    render();
+    const slider = document.querySelector('.customize-bar input[type="range"][min="1"][max="6"]');
+    slider.value = '4';
+    slider.dispatchEvent({type:'input'});
+    expect(state.ui.colCount.overview).toBe(4);
+    const grid = document.getElementById('ov-grid');
+    expect(grid.getAttribute('style')).toBe('gridTemplateColumns:repeat(4, minmax(0,1fr))');
+  });
+});
+
 describe('addWidgetControls', () => {
   test('resizes and removes widgets', () => {
     const {addWidgetControls} = loadModule('src/widgets.js');


### PR DESCRIPTION
## Summary
- add column-count slider to dashboard Customize bar and persist changes
- drop redundant column settings from UX panel
- test layout control updates grid column count

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af15bbfa88832ba29cec85ee662d48