### PR TITLE
chore: drop jsdoc dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,6 @@ The compiled assets will be output to the `dist/` folder.
 npm test
 ```
 
-## Documentation
-
-```bash
-npm run docs
-```
-
-Open `docs/index.html` in your browser to preview the generated API docs.
-
 ## Configuration
 
 Widgets and dashboard panels can be customized through the in-app settings.

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "start": "node utils.js",
     "test": "jest",
     "dev": "vite",
-    "build": "vite build",
-    "docs": "jsdoc -c jsdoc.json"
+    "build": "vite build"
   },
   "repository": {
     "type": "git",
@@ -30,7 +29,6 @@
   "devDependencies": {
     "vite": "^5.0.0",
     "jest": "^29.x",
-    "esbuild": "^0.19.0",
-    "jsdoc": "^4.0.0"
+    "esbuild": "^0.19.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove jsdoc dev dependency and docs script to unblock npm install
- clean README by dropping docs section

## Testing
- `npm install` *(fails: Unknown env config "http-proxy" ... MaxListenersExceededWarning)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af21bc638c832b9585a07f8c4e5f16