### PR TITLE
ci: add node workflow with dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- add CI workflow to run tests and builds with npm dependency cache

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdoc)*
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2487f788832ba68a121d1844f283