### PR TITLE
fix: export PayCalendarWidget

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -907,7 +907,7 @@ function ChangedTodayWidget(cfg){
     return h('tr',null, h('td',null,c?.name||'—'), h('td',null, fmtUSD(d('totalBalance'))), h('td',null, fmtUSD(d('amountDue'))), h('td',null, fmtUSD(d('availableCredit'))));
   })))];
 }
-function PayCalendarWidget(cfg){
+export function PayCalendarWidget(cfg){
   const latest=latestByCard();
   const start=new Date();
   start.setDate(start.getDate()-start.getDay());


### PR DESCRIPTION
## Summary
- export PayCalendarWidget so tests and other modules can reuse it
- keep todayISO available to callers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af2c14a8ec832b9866a879657bcb31