### PR TITLE
chore: add docs generation script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "devDependencies": {
         "esbuild": "^0.19.0",
         "jest": "^29.x",
-        "vite": "^5.0.0"
+        "vite": "^5.0.0",
+        "jsdoc": "^4.0.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4131,6 +4132,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.2",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "node utils.js",
     "test": "jest",
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "docs": "jsdoc -c jsdoc.json"
   },
   "repository": {
     "type": "git",
@@ -29,6 +30,7 @@
   "devDependencies": {
     "vite": "^5.0.0",
     "jest": "^29.x",
-    "esbuild": "^0.19.0"
+    "esbuild": "^0.19.0",
+    "jsdoc": "^4.0.2"
   }
 }


### PR DESCRIPTION
## Summary
- add `docs` npm script for generating JSDoc
- include `jsdoc` as dev dependency and update lockfile

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af41f4ec50832b8440bbe372424c28