### PR TITLE
ci: build docs on PR and deploy from main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,7 @@ name: Build Docs
 on:
   push:
     branches: [ "main" ]
+  pull_request:
   workflow_dispatch:
 permissions:
   contents: read
@@ -20,8 +21,10 @@ jobs:
           node-version: 18
       - run: npm ci
       - run: npm run docs
-      - uses: actions/upload-pages-artifact@v3
+      - if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions/upload-pages-artifact@v3
         with:
           path: docs
-      - id: deployment
+      - if: ${{ github.ref == 'refs/heads/main' }}
+        id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- run docs workflow on pull requests for validation
- deploy docs only when pushed to main

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af41f9a0b0832b8cebf243bae356f7