### PR TITLE
ci: build before pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,12 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: '.'
+          path: dist
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- setup Node and dependencies for Pages workflow
- build site before deploying to pages
- upload built dist directory

## Testing
- ⚠️ `npm test` *(jest: not found)*
- ⚠️ `npm run build` *(vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af42002d80832ba37a7155fb834f57