### PR TITLE
ci: update Node.js to v20 in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - run: npm ci
       - run: npm run docs
       - if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
## Summary
- use Node.js 20 in CI workflow
- use Node.js 20 in docs workflow

## Testing
- `npm test` *(fails: TypeError: Cannot set properties of null)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af708e5ac0832bac4194d0984915db