### PR TITLE
ci: add fallback page URL for docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- add empty-string fallback to docs workflow environment URL

## Testing
- `npm test` *(fails: Cannot set properties of null)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af708f0c60832b930f3a21f11bca74