### PR TITLE
ci: consolidate docs build with pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,14 +6,9 @@ on:
   workflow_dispatch:
 permissions:
   contents: read
-  pages: write
-  id-token: write
 jobs:
   docs:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url || '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,12 +16,3 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run docs
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - if: ${{ github.ref == 'refs/heads/main' }}
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs
-      - if: ${{ github.ref == 'refs/heads/main' }}
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,6 +20,8 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run build
+      - run: npm run docs
+      - run: mkdir -p dist/docs && cp -r docs/* dist/docs
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- remove GitHub Pages deployment from docs workflow
- build docs alongside app and include in Pages artifact

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b06971ddd4832ba34f1408ad43f294