### PR TITLE
chore(jsdoc): set sourceType to module

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -7,5 +7,6 @@
   "opts": {
     "destination": "docs",
     "recurse": true
-  }
+  },
+  "sourceType": "module"
 }


### PR DESCRIPTION
## Summary
- configure JSDoc to treat sources as ES modules

## Testing
- `npm test` *(fails: Cannot set properties of null; 3 failing tests)*
- `npm run build`
- `npm run docs` *(fails: jsdoc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b069731448832b85950b8f79cbfaa3