### PR TITLE
Fix expense amounts not importing correctly

### DIFF
--- a/backend/src/services/csvImportService.js
+++ b/backend/src/services/csvImportService.js
@@ -75,9 +75,9 @@ function parseTransactionRow(row, lineNumber) {
 
   // Find amount column - handle both single amount and debit/credit columns
   let amount = 0;
-  const amountFields = ['amount', 'transaction_amount', 'trans_amount'];
-  const debitFields = ['debit', 'withdrawal', 'withdrawals', 'debit_amount'];
-  const creditFields = ['credit', 'deposit', 'deposits', 'credit_amount'];
+  const amountFields = ['amount', 'transaction_amount', 'trans_amount', 'value', 'total'];
+  const debitFields = ['debit', 'withdrawal', 'withdrawals', 'debit_amount', 'expense', 'expenses', 'payment', 'payments', 'charge', 'charges', 'spent'];
+  const creditFields = ['credit', 'deposit', 'deposits', 'credit_amount', 'income', 'revenue', 'received', 'receipt', 'receipts'];
 
   // Check for single amount column
   const amountValue = findFieldValue(row, amountFields);

--- a/frontend/src/components/CSVImportModal.jsx
+++ b/frontend/src/components/CSVImportModal.jsx
@@ -295,9 +295,10 @@ export default function CSVImportModal({ isOpen, onClose, onImportComplete, acco
                     <p className="font-medium mb-1">CSV Format Guidelines:</p>
                     <ul className="list-disc list-inside space-y-1">
                       <li>File must include headers in the first row</li>
-                      <li>Required columns: Date, Description, Amount (or Debit/Credit)</li>
+                      <li>Required columns: Date, Description, Amount (or Debit/Credit/Expense/Payment)</li>
                       <li>Optional columns: Reference, Check Number, Transaction ID</li>
                       <li>Various date formats are supported (MM/DD/YYYY, YYYY-MM-DD, etc.)</li>
+                      <li>Amount columns: amount, debit, credit, expense, payment, withdrawal, deposit, etc.</li>
                     </ul>
                   </div>
                 </div>


### PR DESCRIPTION
…CSV imports

Expanded the CSV parser to recognize additional column names commonly used in expense export files. This fixes an issue where expense amounts weren't being imported when the CSV used column names like 'expense', 'payment', 'charge', or other variations instead of the standard 'debit' or 'amount'.

Changes:
- Added expense-related column names: expense, expenses, payment, payments, charge, charges, spent
- Added income-related column names: income, revenue, received, receipt, receipts
- Added general amount variations: value, total
- Updated UI documentation to reflect the expanded column support

This ensures better compatibility with various bank and expense tracking CSV exports.